### PR TITLE
Fixing compilation errors

### DIFF
--- a/Core/DataStructures/VMAudioObject.m
+++ b/Core/DataStructures/VMAudioObject.m
@@ -185,7 +185,7 @@
 }
 
 
-/*
+#if 0
  
 	depreciated
  
@@ -223,10 +223,10 @@
 	}
 	return image;
 }
-*/
+#endif
 
-/*
- 
+#if 0
+
  //
  //
  //
@@ -245,7 +245,7 @@
  that is obtained straight from the fft.
  Tested and working.
  Cheers!
- * /
+ */
 
 #include <iostream>
 #include <Accelerate/Accelerate.h>
@@ -292,7 +292,7 @@ int main(int argc, const char * argv[])
 	
     fftSetup = vDSP_create_fftsetup(log2n, FFT_RADIX2);
 	
-    /* Carry out a Forward and Inverse FFT transform. * /
+    /* Carry out a Forward and Inverse FFT transform. */
     vDSP_ctoz((COMPLEX *) input, 2, &A, 1, L/2);
     vDSP_fft_zrip(fftSetup, &A, 1, log2n, FFT_FORWARD);
 	
@@ -369,6 +369,6 @@ int main(int argc, const char * argv[])
 	
 }
 
-*/
-
+#endif
+ 
 @end

--- a/Core/DataStructures/VMDataTypes.m
+++ b/Core/DataStructures/VMDataTypes.m
@@ -1844,12 +1844,13 @@ VMOBLIGATORY_setWithData()
 						if ( ! f.type == vmObjectType_sequence ) {
 							//	(2) sum the duration of audiofragments and selectors inside.
 							
-
+							
 							//	(4) for sequences inside, clone the main route until this selector, make routes for sequences.
+							
+						}
 						
+						break;
 					}
-					
-					break;
 				}
 				case vmObjectType_audioFragment: {
 					//	audio


### PR DESCRIPTION
BTW: `NSDate` doesn’t appear to have a “-timestamp” method. And there are several other warnings in Xcode 5.
